### PR TITLE
Add license tag

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ setuptools.setup(
     version='0.8',
     author="Brian Marks",
     description="Python API for the Frigidaire 2.0 App",
+    license="MIT",
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/bm1549/frigidaire",


### PR DESCRIPTION
Allow third-party tools (e. g., PyPI or `pyp2rpm`) to get the license details in a simple way.