### PR TITLE
Add Enum for connectivity state

### DIFF
--- a/frigidaire/__init__.py
+++ b/frigidaire/__init__.py
@@ -185,6 +185,11 @@ class FanSpeed(Enum):
     AUTO = 7
 
 
+class ConnectivityState(Enum):
+    CONNECTED = 'connect'
+    DISCONNECTED = 'disconnect'
+
+
 class Action:
     @classmethod
     def set_power(cls, power: Power) -> List[Component]:

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name='frigidaire',
-    version='0.13',
+    version='0.14',
     author="Brian Marks",
     description="Python API for the Frigidaire 2.0 App",
     license="MIT",


### PR DESCRIPTION
Just adds an enum for the constants in the 0000 connectivity state hacl detail. For https://github.com/bm1549/home-assistant-frigidaire/pull/8