### PR TITLE
New Dehumidifier modes

### DIFF
--- a/frigidaire/__init__.py
+++ b/frigidaire/__init__.py
@@ -181,7 +181,9 @@ class Mode(int, Enum):
     ECO = 4
     # Dehumidifier
     DRY = 5
+    AUTO = 6
     CONTINUOUS = 8
+    QUIET = 9
 
 
 class FanSpeed(int, Enum):

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name='frigidaire',
-    version='0.16',
+    version='0.17',
     author="Brian Marks",
     description="Python API for the Frigidaire 2.0 App",
     license="MIT",


### PR DESCRIPTION
Adds more dehumidifier modes to the enum from [HA forum](https://community.home-assistant.io/t/frigidaire-air-conditioners/198791/36?u=gazpachoking)

Now we have to figure out how to detect what different modes a given humidifier supports on the HA side. @bm1549 I tried getting mitmproxy working on an android emulator, which is working sorta, but my dehumidifier always shows disconnected, so I don't get any of the requests after the login and get appliance stuff. Do you have some tips on how you got that working?


Courtesy of newmanzone on the forum:
Here are the modes:

**Auto**

```
number_value: 6
string_value: 'Auto'
```

**Quiet**

```
number_value: 9
string_value: 'Quiet'
```

**Dry**

```
number_value: 5
string_value: 'Dry'
```

**Continuous**

```
number_value: 8
string_value: 'Continuous'
```
