### PR TITLE
Detect appliance class more accurately

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,6 @@ dmypy.json
 
 # PyCharm
 .idea/
+
+# Frigidaire creds
+config.ini

--- a/test.py
+++ b/test.py
@@ -1,3 +1,4 @@
+import configparser
 import logging
 
 from frigidaire import Action, Power, Mode, FanSpeed, Frigidaire, HaclCode, Component
@@ -5,9 +6,20 @@ from frigidaire import Action, Power, Mode, FanSpeed, Frigidaire, HaclCode, Comp
 if __name__ == '__main__':
     logging.basicConfig(level=logging.DEBUG)
 
-    username = 'email@example.com'
-    password = 'password'
-    session_key = 'get_this_from_authenticate'
+    # Create a config file at config.ini to reduce the risk of accidentally committing credentials
+    # You can use the following contents as a starting point
+    """
+    [credentials]
+    Username=email@example.com
+    Password=password
+    """
+    config = configparser.ConfigParser()
+    config.read('config.ini')
+    credentials = config['credentials'] or {}
+
+    username = credentials.get('username')
+    password = credentials.get('password')
+    session_key = credentials.get('session_key', fallback=None)
 
     frigidaire = Frigidaire(
         username,


### PR DESCRIPTION
Better detects appliance class (AC vs de-humidifier) by making an additional call to the `appliance_details` endpoint when calling `get_appliances`

This resolves https://github.com/bm1549/home-assistant-frigidaire/issues/11 and any similar issues people are having

This PR also updates `test.py` to allow the usage of a `config.ini` file to make it harder to accidentally commit credentials 😄 