### PR TITLE
Fix error setting fan speed

### DIFF
--- a/frigidaire/__init__.py
+++ b/frigidaire/__init__.py
@@ -192,7 +192,7 @@ class Action:
 
     @classmethod
     def set_fan_speed(cls, fan_speed: FanSpeed) -> List[Component]:
-        return [Component(Setting.FAN_SPEED_SETTING, fan_speed)]
+        return [Component(Setting.FAN_SPEED, fan_speed)]
 
     @classmethod
     def set_humidity(cls, humidity: int) -> List[Component]:


### PR DESCRIPTION
Currently, setting fan speed appears to cause an error: https://github.com/bm1549/frigidaire/issues/27

This fix causes the library to set the fan speed instead of triggering an error.

Tested: https://github.com/rothn/home-assistant-frigidaire/tree/in-tree-frigidaire-for-testing