### PR TITLE
Expose set_temperature_f and set_temperature_c functions

### DIFF
--- a/frigidaire/__init__.py
+++ b/frigidaire/__init__.py
@@ -202,13 +202,25 @@ class Action:
         return [Component(Setting.TARGET_HUMIDITY, humidity)]
 
     @classmethod
-    def set_temperature(cls, temperature: int) -> List[Component]:
+    def set_temperature_c(cls, temperature: int) -> List[Component]:
         # Note: Frigidaire sets limits for temperature which could cause this action to fail
         # Temperature ranges are below, inclusive of the endpoints
         #   Fahrenheit: 60-90
         #   Celsius: 16-32
+        logging.debug("Client setting target to {} C".format(temperature))
+
         return [
-            Component(Setting.TEMPERATURE_REPRESENTATION, Unit.FAHRENHEIT),
+            Component(Setting.TARGET_TEMPERATURE_C, temperature),
+        ]
+    @classmethod
+    def set_temperature_f(cls, temperature: int) -> List[Component]:
+        # Note: Frigidaire sets limits for temperature which could cause this action to fail
+        # Temperature ranges are below, inclusive of the endpoints
+        #   Fahrenheit: 60-90
+        #   Celsius: 16-32
+        logging.debug("Client setting target to {} F".format(temperature))
+
+        return [
             Component(Setting.TARGET_TEMPERATURE_F, temperature),
         ]
 


### PR DESCRIPTION
Expose set_temperature_{f,c} functions wrapping the underlinging Frigidaire actions Setting.TARGET_TEMPERATURE_{F,C}. This allows users of this client (e.g. the Home Assistant component) to set a target temperature in either F or C without performing temperature conversion; callers that natively use F will set the TARGET_TEMPERATURE_F, while callers that store C will set the TARGET_TEMPERATURE_C.

These two functions replace the previous `set_temperature()` function (which implicitly required callers to convert target temperatures to degrees Fahrenheit), and so constitute a **breaking API change.**

Supports fixing https://github.com/bm1549/home-assistant-frigidaire/issues/56

Should also address remaining issues with #19 (as noted in https://github.com/bm1549/frigidaire/pull/34#issuecomment-2215714356)