### PR TITLE
Allow setting of temperature unit (F or C) when setting temperature

### DIFF
--- a/frigidaire/__init__.py
+++ b/frigidaire/__init__.py
@@ -202,13 +202,25 @@ class Action:
         return [Component(Setting.TARGET_HUMIDITY, humidity)]
 
     @classmethod
-    def set_temperature(cls, temperature: int) -> List[Component]:
+    def set_temperature_c(cls, temperature: int) -> List[Component]:
         # Note: Frigidaire sets limits for temperature which could cause this action to fail
         # Temperature ranges are below, inclusive of the endpoints
         #   Fahrenheit: 60-90
         #   Celsius: 16-32
+        logging.debug("Client setting target to {} C".format(temperature))
+
         return [
-            Component(Setting.TEMPERATURE_REPRESENTATION, Unit.FAHRENHEIT),
+            Component(Setting.TARGET_TEMPERATURE_C, temperature),
+        ]
+    @classmethod
+    def set_temperature_f(cls, temperature: int) -> List[Component]:
+        # Note: Frigidaire sets limits for temperature which could cause this action to fail
+        # Temperature ranges are below, inclusive of the endpoints
+        #   Fahrenheit: 60-90
+        #   Celsius: 16-32
+        logging.debug("Client setting target to {} F".format(temperature))
+
+        return [
             Component(Setting.TARGET_TEMPERATURE_F, temperature),
         ]
 

--- a/frigidaire/__init__.py
+++ b/frigidaire/__init__.py
@@ -202,26 +202,17 @@ class Action:
         return [Component(Setting.TARGET_HUMIDITY, humidity)]
 
     @classmethod
-    def set_temperature_c(cls, temperature: int) -> List[Component]:
+    def set_temperature(cls, temperature: int, temperature_unit: Unit = Unit.FAHRENHEIT) -> List[Component]:
         # Note: Frigidaire sets limits for temperature which could cause this action to fail
         # Temperature ranges are below, inclusive of the endpoints
         #   Fahrenheit: 60-90
         #   Celsius: 16-32
-        logging.debug("Client setting target to {} C".format(temperature))
+        logging.debug("Client setting target to {} {}".format(temperature, temperature_unit))
+        temperature_unit_setting = Setting.TARGET_TEMPERATURE_F if temperature_unit == Unit.FAHRENHEIT else Setting.TARGET_TEMPERATURE_C
 
         return [
-            Component(Setting.TARGET_TEMPERATURE_C, temperature),
-        ]
-    @classmethod
-    def set_temperature_f(cls, temperature: int) -> List[Component]:
-        # Note: Frigidaire sets limits for temperature which could cause this action to fail
-        # Temperature ranges are below, inclusive of the endpoints
-        #   Fahrenheit: 60-90
-        #   Celsius: 16-32
-        logging.debug("Client setting target to {} F".format(temperature))
-
-        return [
-            Component(Setting.TARGET_TEMPERATURE_F, temperature),
+            Component(Setting.TEMPERATURE_REPRESENTATION, temperature_unit),
+            Component(temperature_unit_setting, temperature),
         ]
 
 


### PR DESCRIPTION
Built on top of #37 (thank you @casebeer !)

Allows for the setting of temperature [Unit](https://github.com/bm1549/frigidaire/blob/bfa28e108d128e13aadbe85b91b49fc9918033e5/frigidaire/__init__.py#L127) (either `Unit.FAHRENHEIT` or `Unit.CELSIUS`) when using `set_temperature`

Supports fixing https://github.com/bm1549/home-assistant-frigidaire/issues/56

Should also address remaining issues with #19 (as noted in https://github.com/bm1549/frigidaire/pull/34#issuecomment-2215714356)