### PR TITLE
Redact credentials from request-failure logs

### DIFF
--- a/frigidaire/__init__.py
+++ b/frigidaire/__init__.py
@@ -34,6 +34,30 @@ CLIENT_ID = "FrigidaireOneApp"
 FRIGIDAIRE_USER_AGENT = "Ktor client"
 AUTH_USER_AGENT = "Dalvik/2.1.0 (Linux; U; Android 12; sdk_gphone64_x86_64 Build/SE1A.220826.008)"
 
+# Header names whose values are credentials; matched case-insensitively.
+_REDACT_HEADERS = frozenset({"authorization", "x-api-key"})
+
+# Top-level JSON keys whose values are credentials in auth-flow request bodies.
+_REDACT_PAYLOAD_KEYS = frozenset(
+    {"password", "clientSecret", "apiKey", "oauth_token", "idToken", "id_token", "sig", "accessToken"}
+)
+
+
+def _redact_headers(headers: dict[str, str]) -> dict[str, str]:
+    return {k: ("<redacted>" if k.lower() in _REDACT_HEADERS else v) for k, v in headers.items()}
+
+
+def _redact_payload(payload: str) -> str:
+    if not payload:
+        return payload
+    try:
+        data = json.loads(payload)
+    except (json.JSONDecodeError, TypeError):
+        return payload
+    if not isinstance(data, dict):
+        return payload
+    return json.dumps({k: ("<redacted>" if k in _REDACT_PAYLOAD_KEYS else v) for k, v in data.items()})
+
 
 class FrigidaireException(Exception):
     pass
@@ -634,8 +658,15 @@ class Frigidaire:
     def handle_request_exception(
         e: Exception, method: str, fullpath: str, headers: dict[str, str], payload: str
     ) -> NoReturn:
-        logging.warning(e)
-        error_str = f"Error processing request:\n{method} {fullpath}\nheaders={headers}\npayload={payload}\n"
+        # Don't log `e` directly: parse_response wraps response bodies into the
+        # exception message, and auth-endpoint bodies contain tokens. Callers
+        # who need it can inspect __cause__ on the raised exception.
+        safe_headers = _redact_headers(headers)
+        safe_payload = _redact_payload(payload)
+        error_str = (
+            f"Error processing request ({type(e).__name__}):\n"
+            f"{method} {fullpath}\nheaders={safe_headers}\npayload={safe_payload}\n"
+        )
         logging.warning(error_str)
         raise FrigidaireException(error_str) from e
 

--- a/tests/test_redaction.py
+++ b/tests/test_redaction.py
@@ -1,0 +1,96 @@
+"""Regression: credentials must not appear in error logs or exceptions.
+
+Issue #41 in this repo had a user paste their full bearer token into a public
+GitHub issue because handle_request_exception logged unredacted headers.
+Auth-flow payloads also contain plaintext passwords and tokens.
+"""
+
+import json
+import logging
+
+import pytest
+
+from frigidaire import Frigidaire, FrigidaireException, _redact_headers, _redact_payload
+
+FAKE_JWT = "eyJhbGciOiJIUzI1NiJ9.test-payload.test-signature"
+FAKE_API_KEY = "test-api-key-do-not-leak"
+FAKE_PASSWORD = "test-password-do-not-leak"
+
+
+def test_redact_headers_masks_credentials() -> None:
+    redacted = _redact_headers(
+        {"Authorization": f"Bearer {FAKE_JWT}", "x-api-key": FAKE_API_KEY, "Accept": "application/json"}
+    )
+    assert FAKE_JWT not in str(redacted)
+    assert FAKE_API_KEY not in str(redacted)
+    assert redacted["Accept"] == "application/json"
+
+
+def test_redact_headers_is_case_insensitive() -> None:
+    redacted = _redact_headers({"AUTHORIZATION": f"Bearer {FAKE_JWT}", "X-API-KEY": FAKE_API_KEY})
+    assert FAKE_JWT not in str(redacted)
+    assert FAKE_API_KEY not in str(redacted)
+
+
+def test_redact_payload_masks_known_sensitive_keys() -> None:
+    payload = json.dumps(
+        {
+            "loginID": "user@example.com",
+            "password": FAKE_PASSWORD,
+            "clientSecret": "secret-do-not-leak",
+            "idToken": FAKE_JWT,
+            "apiKey": FAKE_API_KEY,
+            "sig": "hmac-sig-do-not-leak",
+            "format": "json",
+        }
+    )
+    redacted = _redact_payload(payload)
+    assert FAKE_PASSWORD not in redacted
+    assert "secret-do-not-leak" not in redacted
+    assert FAKE_JWT not in redacted
+    assert FAKE_API_KEY not in redacted
+    assert "hmac-sig-do-not-leak" not in redacted
+    # Non-sensitive fields preserved
+    assert "user@example.com" in redacted
+    assert "json" in redacted
+
+
+def test_redact_payload_passes_through_non_json() -> None:
+    """Form-encoded or malformed bodies are returned untouched (better to log
+    raw than to crash the error path)."""
+    assert _redact_payload("") == ""
+    assert _redact_payload("not-json-at-all") == "not-json-at-all"
+    # JSON arrays and primitives are passed through (no top-level keys to redact)
+    assert _redact_payload("[1, 2, 3]") == "[1, 2, 3]"
+
+
+def test_handle_request_exception_redacts_in_message_and_log(caplog: pytest.LogCaptureFixture) -> None:
+    headers = {
+        "Authorization": f"Bearer {FAKE_JWT}",
+        "x-api-key": FAKE_API_KEY,
+        "User-Agent": "Ktor client",
+    }
+    payload = json.dumps({"loginID": "user@example.com", "password": FAKE_PASSWORD})
+    caplog.set_level(logging.WARNING)
+    with pytest.raises(FrigidaireException) as exc_info:
+        Frigidaire.handle_request_exception(RuntimeError("boom"), "POST", "https://example.com/login", headers, payload)
+
+    leaked = (FAKE_JWT, FAKE_API_KEY, FAKE_PASSWORD)
+    for secret in leaked:
+        assert secret not in str(exc_info.value), f"{secret!r} leaked into raised exception"
+        assert secret not in caplog.text, f"{secret!r} leaked into warning log"
+    # Sanity: non-sensitive context still present
+    assert "Ktor client" in str(exc_info.value)
+    assert "user@example.com" in str(exc_info.value)
+
+
+def test_handle_request_exception_does_not_log_inner_exception_unredacted(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Inner FrigidaireExceptions from parse_response carry the response body,
+    which for auth endpoints can contain tokens."""
+    inner = FrigidaireException(f'Request failed with status 200: b\'{{"id_token": "{FAKE_JWT}"}}\'')
+    caplog.set_level(logging.WARNING)
+    with pytest.raises(FrigidaireException):
+        Frigidaire.handle_request_exception(inner, "POST", "https://example.com/jwt", {}, "")
+    assert FAKE_JWT not in caplog.text, "inner exception leaked a token into the warning log"


### PR DESCRIPTION
## Summary

`handle_request_exception` writes the full request context to logs on any HTTP failure. Three credential leaks fixed in one place:

- **Headers** — `Authorization` and `x-api-key` were logged verbatim. Issue #41 in this repo has a user's complete bearer-token JWT pasted into a public bug report as a result.
- **Payloads** — auth-flow request bodies were logged verbatim, including the user's plaintext `password` (accounts.login), `clientSecret`, `idToken`, `oauth_token`, and HMAC `sig`.
- **Inner exception** — `logging.warning(e)` bypassed redaction; when `e` came from `parse_response` it carried the response body, which for auth endpoints includes `id_token` / `accessToken`.

Adds `_redact_headers` (case-insensitive) and `_redact_payload` (parses JSON, masks known sensitive top-level keys, falls through for non-JSON). The bare `logging.warning(e)` becomes `type(e).__name__` in the existing `error_str`; callers can still inspect the original exception via `__cause__` on the raised `FrigidaireException`.

## Test plan

- [x] `pytest` — 79 passed
- [x] `ruff check .` and `ruff format --check .` — clean
- [x] `mypy frigidaire/` — clean
- [x] New `tests/test_redaction.py` covers helper unit behavior, case-insensitivity, end-to-end via `handle_request_exception` for headers + payload, and the inner-exception leak path

🤖 Generated with [Claude Code](https://claude.com/claude-code)