### PR TITLE
ci: add dependabot config for pip and github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` with weekly update schedule for `pip` and `github-actions` ecosystems.

## Test plan
- [ ] Dependabot picks up the config and starts opening update PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)