### PR TITLE
deps: trim install_requires to direct deps only

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,0 @@
-certifi==2020.12.5
-chardet==4.0.0
-idna==2.10
-requests==2.34.1
-urllib3==1.26.4

--- a/setup.py
+++ b/setup.py
@@ -18,13 +18,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/bm1549/frigidaire",
     packages=setuptools.find_packages(),
-    install_requires=[
-        "certifi>=2020.12.5",
-        "chardet>=4.0.0",
-        "idna>=2.10",
-        "requests>=2.25.1",
-        "urllib3>=1.26.4",
-    ],
+    install_requires=["requests>=2.25.1"],
     extras_require={
         "dev": [
             "pytest>=7.0",


### PR DESCRIPTION
## Summary
- `setup.py`: drop `certifi`, `chardet`, `idna`, `urllib3` from `install_requires`. They are transitive deps of `requests` that pip already resolves automatically. Only `requests` is a direct dep of this library.
- Delete `requirements.txt`. It's not referenced by CI (`test.yml` installs with `pip install -e ".[dev]"`) and duplicated `install_requires` with stale pins.

## Side effects
- Dependabot will open ~1 PR per `requests` release instead of ~5 PRs per release across `requests` + its transitives.
- Consumers of `frigidaire` (notably `home-assistant-frigidaire`) are unaffected: pip still installs the same transitive deps, just resolved by `requests` itself.

## Test plan
- [ ] CI passes (lint, mypy, tests on 3.10 and 3.12).
- [ ] Verify `pip install frigidaire` in a fresh env still pulls in `requests` + its transitives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)