### PR TITLE
ci: base diff link on currently-pinned version

### DIFF
--- a/.github/workflows/automatic-python-publish.yml
+++ b/.github/workflows/automatic-python-publish.yml
@@ -54,5 +54,4 @@ jobs:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         gh workflow run bump-ha-plugin.yml \
-          -f version="${{ steps.semvers.outputs.patch }}" \
-          -f previous_version="${{ steps.previoustag.outputs.tag }}"
+          -f version="${{ steps.semvers.outputs.patch }}"

--- a/.github/workflows/bump-ha-plugin.yml
+++ b/.github/workflows/bump-ha-plugin.yml
@@ -7,10 +7,6 @@ on:
         description: "frigidaire version to pin in the HA plugin manifest"
         required: true
         type: string
-      previous_version:
-        description: "previous frigidaire version (for the compare-view link in the PR body)"
-        required: true
-        type: string
 
 jobs:
   bump:
@@ -21,6 +17,11 @@ jobs:
         with:
           repository: bm1549/home-assistant-frigidaire
           token: ${{ secrets.HA_PLUGIN_TOKEN }}
+      - name: Capture currently pinned version
+        id: current
+        run: |
+          CURRENT=$(grep -oP '"frigidaire==\K[^"]+' custom_components/frigidaire/manifest.json)
+          echo "version=$CURRENT" >> "$GITHUB_OUTPUT"
       - name: Bump frigidaire pin in manifest
         env:
           VERSION: ${{ inputs.version }}
@@ -38,7 +39,7 @@ jobs:
             Automated bump of the `frigidaire` library pin to **${{ inputs.version }}**.
 
             - Release notes: https://github.com/bm1549/frigidaire/releases/tag/${{ inputs.version }}
-            - Diff: https://github.com/bm1549/frigidaire/compare/${{ inputs.previous_version }}...${{ inputs.version }}
+            - Diff: https://github.com/bm1549/frigidaire/compare/${{ steps.current.outputs.version }}...${{ inputs.version }}
             - PyPI: https://pypi.org/project/frigidaire/${{ inputs.version }}/
 
             Updates `custom_components/frigidaire/manifest.json`.


### PR DESCRIPTION
## Summary
The diff link in the auto-bump PR currently uses the previous *frigidaire library* tag as the "from" side. But the HA plugin's pin may be several versions behind, so the link should reflect what this specific PR is actually moving from → to.

Example: HA plugin pins `0.18.32`, publish runs for `0.18.42`. Old link: `compare/0.18.41...0.18.42` (just the latest delta). New link: `compare/0.18.32...0.18.42` (everything actually being applied).

## Changes
- `bump-ha-plugin.yml`: new step reads the currently-pinned version out of the manifest before the sed replace, exposes it as a step output, and uses it for the compare URL.
- `automatic-python-publish.yml`: drop the `previous_version` input we were passing — it's now derived inside the bump workflow.

## Test plan
- [ ] Merge.
- [ ] Confirm the next publish updates PR #108 (or opens a new one if it was merged) with a compare link pointing from the previously-pinned version to the new release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)