### PR TITLE
Add waterTankFull as a recognized Detail for dehumidifiers

### DIFF
--- a/frigidaire/__init__.py
+++ b/frigidaire/__init__.py
@@ -119,7 +119,7 @@ _AC_PROPERTY_KEYS = {
     "ambientTemperatureF",
     "temperatureRepresentation",
 }
-_DH_PROPERTY_KEYS = {"targetHumidity", "sensorHumidity", "waterBucketLevel"}
+_DH_PROPERTY_KEYS = {"targetHumidity", "sensorHumidity", "waterBucketLevel", "waterTankFull"}
 
 
 class Setting(str, Enum):
@@ -183,6 +183,7 @@ class Detail(str, Enum):
     STOP_TIME = "stopTime"
     TARGET_HUMIDITY = "targetHumidity"
     WATER_BUCKET_LEVEL = "waterBucketLevel"
+    WATER_TANK_FULL = "waterTankFull"
 
 
 class Appliance:

--- a/tests/test_destination.py
+++ b/tests/test_destination.py
@@ -50,6 +50,13 @@ def test_appliance_infers_dh_from_humidity_keys(caplog: pytest.LogCaptureFixture
     assert "inferred DEHUMIDIFIER" in caplog.text
 
 
+def test_appliance_infers_dh_from_water_tank_full_key(caplog: pytest.LogCaptureFixture) -> None:
+    caplog.set_level(logging.WARNING)
+    appliance = Appliance(_raw("UnknownCodename", reported={"waterTankFull": "YES"}))
+    assert appliance.destination is Destination.DEHUMIDIFIER
+    assert "inferred DEHUMIDIFIER" in caplog.text
+
+
 def test_appliance_infers_ac_from_temperature_keys(caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level(logging.WARNING)
     appliance = Appliance(_raw("UnknownCodename", reported={"targetTemperatureF": 72, "ambientTemperatureF": 70}))


### PR DESCRIPTION
## Summary
- Some dehumidifier models (e.g. GHDD5035W1) report tank-full state via `waterTankFull` (`'YES'`/presumably `'NO'`) instead of the `waterBucketLevel` field or a `BUCKET_FULL` alert.
- Adds `Detail.WATER_TANK_FULL = "waterTankFull"` and includes it in `_DH_PROPERTY_KEYS` so unknown-codename models reporting this field are still correctly inferred as dehumidifiers.

## Context
Related to bm1549/home-assistant-frigidaire#121 — "Bin Full does not update when water tank is full". The reporter's raw API dump confirmed the `waterTankFull: 'YES'` field; see the paired PR in home-assistant-frigidaire for the consumer-side fallback logic.

Caveat: only one data point (tank full) was available from the issue thread — the "not full" value hasn't been independently confirmed. Would like the reporter to verify against a real device before cutting a release.

## Test plan
- [x] `pytest` (90 existing + 1 new test, all passing)
- [x] `ruff check` / `ruff format --check`
- [ ] Reporter confirms `waterTankFull` correctly reflects tank state on their GHDD5035W1 (full → not full)