### PR TITLE
Expose reported air-quality details and connection state; fix DH inference for ACs reporting humidity

### DIFF
--- a/frigidaire/__init__.py
+++ b/frigidaire/__init__.py
@@ -119,7 +119,9 @@ _AC_PROPERTY_KEYS = {
     "ambientTemperatureF",
     "temperatureRepresentation",
 }
-_DH_PROPERTY_KEYS = {"targetHumidity", "sensorHumidity", "waterBucketLevel", "waterTankFull"}
+# Note: "sensorHumidity" is deliberately absent. It is not DH-exclusive — Telica portable
+# ACs report a room humidity reading, so treating it as a DH marker misidentifies them.
+_DH_PROPERTY_KEYS = {"targetHumidity", "waterBucketLevel", "waterTankFull"}
 
 
 class Setting(str, Enum):
@@ -163,7 +165,12 @@ class Detail(str, Enum):
     FAN_SPEED_STATE = "fanSpeedState"
     FILTER_STATE = "filterState"
     MODE = "mode"
+    # The mode the appliance reports it is *actually* running, which can differ from the
+    # requested MODE — e.g. an ECO/AUTO unit reports "cool" or "fanOnly" as it cycles.
+    MODE_STATE = "modeState"
     NETWORK_INTERFACE = "networkInterface"
+    # Room humidity reading. Reported by dehumidifiers and by some ACs (e.g. Telica).
+    SENSOR_HUMIDITY = "sensorHumidity"
     UI_LOCK_MODE = "uiLockMode"
     SLEEP_MODE = "sleepMode"
     VERTICAL_SWING = "verticalSwing"
@@ -175,10 +182,14 @@ class Detail(str, Enum):
     TARGET_TEMPERATURE_F = "targetTemperatureF"
     TEMPERATURE_REPRESENTATION = "temperatureRepresentation"
 
+    # Air quality, on models with a particulate sensor. Units are µg/m³.
+    PM1 = "pm1"
+    PM10 = "pm10"
+    PM25 = "pm25"
+
     # Humidifier
     DISPLAY_LIGHT = "displayLight"
     CLEAN_AIR_MODE = "cleanAirMode"
-    SENSOR_HUMIDITY = "sensorHumidity"
     START_TIME = "startTime"
     STOP_TIME = "stopTime"
     TARGET_HUMIDITY = "targetHumidity"
@@ -199,9 +210,10 @@ class Appliance:
         except ValueError:
             pass
 
-        # Check DH first: humidity/water-bucket keys are DH-exclusive, while the "AC" keys
-        # (ambient temperature, temperature representation) are also reported by
-        # dehumidifiers that display room temp.
+        # Check DH first: target-humidity/water-bucket keys are DH-exclusive, while the "AC"
+        # keys (ambient temperature, temperature representation) are also reported by
+        # dehumidifiers that display room temp. Note that a humidity *reading*
+        # ("sensorHumidity") is not a DH marker — some ACs report one too.
         reported_keys = set(args.get("properties", {}).get("reported", {}).keys())
         if reported_keys & _DH_PROPERTY_KEYS:
             logging.warning(
@@ -718,6 +730,26 @@ class Frigidaire:
 
         return self._with_reauth(fetch)
 
+    def get_appliance_raw(self, appliance: Appliance) -> dict:
+        """
+        Uses the Frigidaire API to fetch the complete raw record for a given appliance.
+        Will authenticate if the request fails
+
+        Unlike get_appliance_details(), this keeps the keys that live alongside
+        "properties" — notably "connectionState" and "status" — which callers need in order
+        to tell a genuinely offline appliance from stale reported values.
+
+        :param appliance: The appliance to request from the API
+        :return: The full raw appliance record
+        """
+        logging.debug(f"Getting raw appliance record for appliance {appliance.nickname}")
+        raw_appliances = self._with_reauth(self._fetch_raw_appliances)
+
+        for raw_appliance in raw_appliances:
+            if raw_appliance["applianceId"] == appliance.appliance_id:
+                return raw_appliance
+        raise FrigidaireException(f"Appliance {appliance.nickname} not found in list of appliances")
+
     def get_appliance_details(self, appliance: Appliance) -> dict:
         """
         Uses the Frigidaire API to fetch details for a given appliance
@@ -726,12 +758,7 @@ class Frigidaire:
         :return: The details for the passed in appliance
         """
         logging.debug(f"Getting appliance details for appliance {appliance.nickname}")
-        raw_appliances = self._with_reauth(self._fetch_raw_appliances)
-
-        for raw_appliance in raw_appliances:
-            if raw_appliance["applianceId"] == appliance.appliance_id:
-                return raw_appliance["properties"]["reported"]
-        raise FrigidaireException(f"Appliance {appliance.nickname} not found in list of appliances")
+        return self.get_appliance_raw(appliance)["properties"]["reported"]
 
     def execute_action(self, appliance: Appliance, action: list[Component]) -> None:
         """

--- a/tests/test_destination.py
+++ b/tests/test_destination.py
@@ -64,6 +64,32 @@ def test_appliance_infers_ac_from_temperature_keys(caplog: pytest.LogCaptureFixt
     assert "inferred AIR_CONDITIONER" in caplog.text
 
 
+def test_appliance_infers_ac_when_it_also_reports_a_humidity_reading(caplog: pytest.LogCaptureFixture) -> None:
+    """A humidity *reading* is not a dehumidifier marker.
+
+    Telica portable ACs report `sensorHumidity` alongside the usual temperature keys. Keying
+    DH inference off that reading misidentifies them and hands the appliance to the wrong
+    platform. Only the DH-exclusive keys (targetHumidity, waterBucketLevel, waterTankFull)
+    may drive that decision. The payload below is trimmed from a real Telica response.
+    """
+    caplog.set_level(logging.WARNING)
+    appliance = Appliance(
+        _raw(
+            "UnknownCodename",
+            reported={
+                "applianceState": "running",
+                "mode": "fanOnly",
+                "sensorHumidity": 86,
+                "ambientTemperatureF": 72,
+                "targetTemperatureF": 60,
+                "temperatureRepresentation": "fahrenheit",
+            },
+        )
+    )
+    assert appliance.destination is Destination.AIR_CONDITIONER
+    assert "inferred AIR_CONDITIONER" in caplog.text
+
+
 def test_appliance_dh_wins_when_both_keys_present(caplog: pytest.LogCaptureFixture) -> None:
     """DH check comes first because dehumidifiers also report ambient temperature."""
     caplog.set_level(logging.WARNING)

--- a/tests/test_frigidaire_http.py
+++ b/tests/test_frigidaire_http.py
@@ -90,6 +90,50 @@ def test_get_appliance_details_raises_when_not_found() -> None:
 
 
 @responses.activate
+def test_get_appliance_raw_keeps_keys_outside_properties() -> None:
+    """connectionState lives beside `properties`, so get_appliance_details() cannot see it."""
+    client = make_authenticated_client()
+    raw = {
+        "applianceId": "AC1",
+        "applianceData": {"modelName": "AC", "applianceName": "Bedroom"},
+        "properties": {"reported": {"targetTemperatureF": 72, "mode": "COOL"}},
+        "status": "enabled",
+        "connectionState": "Connected",
+    }
+    responses.add(responses.GET, APPLIANCES_URL, json=[raw], status=200)
+
+    assert client.get_appliance_raw(make_appliance(nickname="Bedroom")) == raw
+
+
+@responses.activate
+def test_get_appliance_details_still_returns_only_reported() -> None:
+    """get_appliance_raw() must not change what existing get_appliance_details() callers see."""
+    client = make_authenticated_client()
+    responses.add(
+        responses.GET,
+        APPLIANCES_URL,
+        json=[
+            {
+                "applianceId": "AC1",
+                "applianceData": {"modelName": "AC", "applianceName": "Bedroom"},
+                "properties": {"reported": {"mode": "COOL"}, "desired": {"mode": "DRY"}},
+                "connectionState": "Connected",
+            },
+        ],
+        status=200,
+    )
+    assert client.get_appliance_details(make_appliance(nickname="Bedroom")) == {"mode": "COOL"}
+
+
+@responses.activate
+def test_get_appliance_raw_raises_when_not_found() -> None:
+    client = make_authenticated_client()
+    responses.add(responses.GET, APPLIANCES_URL, json=[], status=200)
+    with pytest.raises(FrigidaireException, match="not found"):
+        client.get_appliance_raw(make_appliance(appliance_id="MISSING"))
+
+
+@responses.activate
 def test_execute_action_puts_each_component_separately() -> None:
     """Action.set_temperature returns 2 components; each must be a separate PUT."""
     client = make_authenticated_client()


### PR DESCRIPTION
## Summary
Hey I used Claude to whip up this patch based on the real responses from my https://www.frigidaire.com/en/p/home-comfort/air-conditioners/portable-air-conditioners/GHPH142AA1 

Please let me know if you want any changes, less verbose comments, etc. I promise there's a human here!

I found several keys in `properties.reported` that callers have no typed way to read, plus one key that is structurally unreachable and a destination-inference bug the same payload exposes.

### 1. New `Detail` members

`MODE_STATE` (`modeState`), `PM25`, `PM10`, `PM1`.

`modeState` is the mode the appliance reports it is *actually* running, as opposed to the
requested `mode`. On an ECO/AUTO unit these differ as the compressor cycles, so it is the
only way a consumer can tell "cooling" from "just running the fan".

`SENSOR_HUMIDITY` also moves from the `# Humidifier` block to `# Common`, because it is not
DH-only — see below.

### 2. `sensorHumidity` is not a dehumidifier marker

`_DH_PROPERTY_KEYS` contains `sensorHumidity`, and `_resolve_destination()` checks that set *first*, with the comment "humidity/water-bucket keys are DH-exclusive". That is not true: the my AC below reports a room humidity reading.

Telica (The codename) is in `_MODEL_MAPPINGS`, so it resolves correctly today. But any **air conditioner with an unrecognised codename that reports `sensorHumidity` is inferred as a `DEHUMIDIFIER`** and handed to the wrong platform.

This PR drops `sensorHumidity` from the set. `targetHumidity`, `waterBucketLevel` and `waterTankFull` remain, and those are genuinely DH-only. Added `test_appliance_infers_ac_when_it_also_reports_a_humidity_reading`, which fails on `main` (inferring `DEHUMIDIFIER`) and passes here.

### 3. New `get_appliance_raw()`

`connectionState` and `status` are siblings of `properties`, so
`get_appliance_details()` — which returns `properties.reported` — discards them. There was no way for a consumer to distinguish a genuinely offline appliance from one whose reported values had simply gone stale, since a disconnected appliance keeps serving its last-known properties.

`get_appliance_raw()` returns the whole record. `get_appliance_details()` now delegates to it and still returns only `properties.reported`, so existing callers are unaffected.

## Evidence

Trimmed live `/appliance/api/v2/appliances` response for (`modelName: "Telica"`), redacted:

```json
{
  "applianceData": { "applianceName": "...", "modelName": "Telica" },
  "properties": { "reported": {
      "applianceState": "running",
      "mode": "fanOnly",
      "modeState": "fanOnly",
      "ambientTemperatureF": 72,
      "targetTemperatureF": 60,
      "temperatureRepresentation": "fahrenheit",
      "sensorHumidity": 86,
      "pm25": 2,
      "pm10": 199,
      "networkInterface": { "linkQualityIndicator": "EXCELLENT", "rssi": -41 }
  } },
  "status": "enabled",
  "connectionState": "Connected"
}
```

Note `pm10`: over five consecutive polls it read `199, 199, 3, 1, 1` while `pm25` read
`2, 2, 3, 1, 1`. When not `199` it is *identical* to `pm25`. The enum member is added for
completeness, but consumers should be wary of it — `199` looks like a placeholder.

## Testing

- `pytest`: 95 passed (91 on `main` + 4 new)
- `ruff check`, `ruff format --check`, `mypy`: clean
- Also exercised end to end against the real appliance via the Home Assistant integration (companion PR in `home-assistant-frigidaire`), confirming `connectionState` reaches a consumer and `modeState` tracks `cool`/`fanOnly` as the mode changes.
